### PR TITLE
🔒 Security Fix: Disable Uvicorn reload by default in entrypoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -215,10 +215,14 @@ async def sitemap():
 
 if __name__ == "__main__":
     import uvicorn
+    # Security Fix: Disable reload by default in production
+    reload_enabled = os.getenv("UVICORN_RELOAD", "false").lower() == "true"
+    port = int(os.getenv("PORT", "8000"))
+
     uvicorn.run(
         "main:app",
         host="0.0.0.0",
-        port=8000,
-        reload=True,
+        port=port,
+        reload=reload_enabled,
         log_level="info"
     )


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR addresses a security vulnerability where `reload=True` was hardcoded in the `uvicorn.run()` call within `app/main.py`. This configuration is insecure for production as it enables auto-reloading and consumes more resources.

⚠️ **Risk:** The potential impact if left unfixed
Running the application directly via `python app/main.py` would start the server in debug mode with auto-reload enabled. This could expose the application to code injection vulnerabilities if the source code is modified at runtime (e.g., in a compromised container volume) and consumes unnecessary CPU resources.

🛡️ **Solution:** How the fix addresses the vulnerability
The `if __name__ == "__main__":` block in `app/main.py` has been updated to:
1.  Read the `UVICORN_RELOAD` environment variable (default: `false`).
2.  Set `reload=True` only if `UVICORN_RELOAD` is explicitly set to `true`.
3.  Read the `PORT` environment variable (default: `8000`) to allow flexible port configuration, aligning with standard practices.

This ensures that the application runs securely by default while still allowing developers to enable reload during development.

---
*PR created automatically by Jules for task [2606298830445658179](https://jules.google.com/task/2606298830445658179) started by @facturx-engine*